### PR TITLE
Add GitHub Actions workflows for CI and npm publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build all packages
+        run: npm run build
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,99 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Package to publish (core, otel, or all)'
+        required: true
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - core
+          - otel
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build all packages
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
+
+  publish-core:
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'release' ||
+      github.event.inputs.package == 'all' ||
+      github.event.inputs.package == 'core'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build all packages
+        run: npm run build
+
+      - name: Publish @irly-tech/zebra-client
+        run: npm publish --workspace=packages/core --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-otel:
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'release' ||
+      github.event.inputs.package == 'all' ||
+      github.event.inputs.package == 'otel'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build all packages
+        run: npm run build
+
+      - name: Publish @irly-tech/zebra-client-otel
+        run: npm publish --workspace=packages/otel --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
-@irly-tech:registry=https://npm.pkg.github.com
+@irly-tech:registry=https://registry.npmjs.org
 @temp-genie:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,8 @@
         "README.md"
     ],
     "publishConfig": {
-        "registry": "https://npm.pkg.github.com"
+        "registry": "https://registry.npmjs.org",
+        "access": "public"
     },
     "scripts": {
         "build": "rimraf dist && tsc",

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -10,7 +10,8 @@
         "README.md"
     ],
     "publishConfig": {
-        "registry": "https://npm.pkg.github.com"
+        "registry": "https://registry.npmjs.org",
+        "access": "public"
     },
     "scripts": {
         "build": "rimraf dist && tsc",


### PR DESCRIPTION
- Add CI workflow that builds and tests on Node.js 18, 20, and 22
- Add publish workflow triggered by releases or manual dispatch
- Update package.json files to use public npm registry
- Update .npmrc for public npm registry support

The publish workflow requires an NPM_TOKEN secret to be configured
in the repository settings.